### PR TITLE
テーブルの処理をStateからReduxに置き換える

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+secrets.json
 
 
 .eslintcache

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,14 +1,26 @@
 import React from 'react'
 import { Redirect, Route, Switch } from 'react-router-dom'
 import styled from 'styled-components'
+import { auth } from './common/firebase/firebaseClient'
 import Layout from './components/Layout/Layout'
 import Document from './pages/Document/Document'
 import Login from './pages/Login/Login'
 import Search from './pages/Search/Search'
 import Top from './pages/Top/Top'
-import { useSelector } from './redux/store'
+import { setUserId, fetchUserInfoWithLogin } from './redux/auth/authSlice'
+import { useSelector, useDispatch } from './redux/store'
 
 function App(): JSX.Element {
+  const dispatch = useDispatch()
+  React.useEffect(() => {
+    // TODO: onAuthStateChangedも含めてReduxに移行する(現状断念)
+    auth.onAuthStateChanged((user) => {
+      if (user) {
+        dispatch(setUserId(user.uid))
+        dispatch(fetchUserInfoWithLogin())
+      }
+    })
+  }, [])
   const currentUser = useSelector((state) => state.auth.user)
   return (
     <Switch>

--- a/src/components/Auth/FirebaseAuth.tsx
+++ b/src/components/Auth/FirebaseAuth.tsx
@@ -69,9 +69,9 @@ function FirebaseAuth(): JSX.Element {
       signInSuccessWithAuthResult: (authResult) => {
         // ログイン成功時にauthcontextに保存する
         // https://firebase.google.com/docs/reference/android/com/google/firebase/auth/AuthResult
-        const user = authResult.user as firebase.User
-        dispatch(setUserId(user.uid))
-        dispatch(fetchUserInfoWithLogin())
+        // const user = authResult.user as firebase.User
+        // dispatch(setUserId(user.uid))
+        // dispatch(fetchUserInfoWithLogin())
         // User successfully signed in.
         // Return type determines whether we continue the redirect automatically
         // or whether we leave that to developer to handle.

--- a/src/components/Layout/AppBar.tsx
+++ b/src/components/Layout/AppBar.tsx
@@ -15,8 +15,8 @@ import React from 'react'
 import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
 import { DRAWER_WIDTH } from '../../common/const'
-import { auth } from '../../common/firebase/firebaseClient'
-import { AuthContext } from '../../context/AuthContext'
+import { logout } from '../../redux/auth/authSlice'
+import { useDispatch, useSelector } from '../../redux/store'
 
 type Props = {
   authenticated: boolean
@@ -29,9 +29,11 @@ export default function Appbar({
   open,
   handleOpen
 }: Props): JSX.Element {
+  const authState = useSelector((state) => state.auth)
+  const dispatch = useDispatch()
+
   const history = useHistory()
   const [anchorEl, setAnchorEl] = React.useState<null | HTMLElement>(null)
-  const { setCurrentUser } = React.useContext(AuthContext)
   const [
     mobileMoreAnchorEl,
     setMobileMoreAnchorEl
@@ -45,10 +47,13 @@ export default function Appbar({
   }
 
   const handleLogout = async () => {
+    /*
     await auth.signOut()
     if (setCurrentUser) {
       setCurrentUser(null)
     }
+    */
+    dispatch(logout())
     window.location.href = '/'
   }
   const handleMobileMenuClose = () => {

--- a/src/redux/documentInfo/documentInfoSlice.ts
+++ b/src/redux/documentInfo/documentInfoSlice.ts
@@ -1,7 +1,9 @@
-import { createSlice } from '@reduxjs/toolkit'
-import firebase from '../../common/firebase/firebaseClient'
+import { createAsyncThunk, createSlice } from '@reduxjs/toolkit'
+import firebase, { db } from '../../common/firebase/firebaseClient'
+import { RootState } from './../store'
+import { DocumentInfo } from '../../schema/documentInfo'
 
-interface DocumentInfo {
+interface TableRowData {
   name: string
   status: string
   fileSize: number
@@ -9,14 +11,22 @@ interface DocumentInfo {
   tags: string[] | undefined
 }
 
+type TableData = Array<TableRowData>
+
+type TableLoadAction = {
+  tableData: TableData
+  snapshot: string | undefined
+  hasMoreItems: boolean
+  errors?: any
+}
+
 type DocumentInfoState = {
   isFetching: boolean
   hasMoreItems: boolean
-  tableData: [] | DocumentInfo[]
-  snapshot:
-    | firebase.firestore.QuerySnapshot<firebase.firestore.DocumentData>
-    | undefined
+  tableData: TableData
+  snapshot: string | undefined
   rowsPerPage: number
+  errors: any
 }
 
 const initialState: DocumentInfoState = {
@@ -24,16 +34,112 @@ const initialState: DocumentInfoState = {
   hasMoreItems: true,
   rowsPerPage: 10,
   tableData: [],
-  snapshot: undefined
+  snapshot: undefined,
+  errors: {}
 }
+
+const createRowData = (
+  doc: firebase.firestore.QueryDocumentSnapshot<firebase.firestore.DocumentData>
+): TableRowData => {
+  const docInfo = doc.data() as DocumentInfo
+  let status = '未処理'
+  if (docInfo.analyzeStatus?.parsedHtmlPath) {
+    status = '解析完了'
+  } else if (docInfo.analyzeStatus?.parsedHtmlPath) {
+    status = 'パース完了'
+  }
+  return {
+    name: docInfo.name,
+    status: status,
+    fileSize: docInfo.size,
+    modifiedAt: docInfo.updatedAt.toDate().toLocaleDateString(),
+    tags: docInfo.tags
+  }
+}
+
+export const fetchDocumentInfo = createAsyncThunk<
+  TableLoadAction,
+  void,
+  { state: RootState }
+>('documentInfo/fetchData', async (_, thunkApi) => {
+  const { auth, documentInfo } = thunkApi.getState()
+  const workspace = auth.user?.workspaces?.[0]
+  if (workspace == null) {
+    return { tableData: [], snapshot: undefined, hasMoreItems: true }
+  }
+
+  try {
+    let query = db
+      .collection('workspaces')
+      .doc(workspace)
+      .collection('documents')
+      .orderBy('updatedAt', 'desc')
+    const { snapshot, rowsPerPage } = documentInfo
+    if (snapshot != null) {
+      // redux-toolkitでsnapshotを保存できないための暫定対処
+      const lastDoc = await db.doc(snapshot).get()
+      query = query.startAfter(lastDoc).limit(rowsPerPage)
+    } else {
+      query = query.limit(rowsPerPage)
+    }
+
+    const tableDataRef = await query.get()
+    const tableDataDocs = tableDataRef.docs
+    const updatedSnapshot = tableDataRef.docs[tableDataRef.size - 1].ref.path
+    const hasMoreItems = tableDataDocs.length < rowsPerPage ? false : true
+    const tableData = tableDataDocs.map(createRowData)
+
+    return {
+      tableData: tableData,
+      snapshot: updatedSnapshot,
+      hasMoreItems: hasMoreItems
+    }
+  } catch (error) {
+    return {
+      tableData: [],
+      snapshot: undefined,
+      errors: error,
+      hasMoreItems: false
+    }
+  }
+})
 
 const documentInfoSlice = createSlice({
   name: 'documentInfo',
   initialState,
-  reducers: {},
-  extraReducers: {}
+  reducers: {
+    isFetching: (state) => {
+      state.isFetching = true
+    },
+    endFetching: (state) => {
+      state.isFetching = false
+    }
+  },
+  extraReducers: (builder) => {
+    builder.addCase(fetchDocumentInfo.pending, (state) => {
+      return {
+        ...state,
+        isFetching: true
+      }
+    })
+    builder.addCase(fetchDocumentInfo.fulfilled, (state, { payload }) => {
+      return {
+        ...state,
+        tableData: state.tableData.concat(payload.tableData),
+        isFetching: false,
+        snapshot: payload.snapshot,
+        hasMoreItems: payload.hasMoreItems
+      }
+    })
+    builder.addCase(fetchDocumentInfo.rejected, (state, action) => {
+      return {
+        ...state,
+        errors: action.error
+      }
+    })
+  }
 })
 
 const { reducer, actions } = documentInfoSlice
-export { actions }
+export const { isFetching } = actions
 export default reducer

--- a/src/redux/documentInfo/documentInfoSlice.ts
+++ b/src/redux/documentInfo/documentInfoSlice.ts
@@ -1,0 +1,39 @@
+import { createSlice } from '@reduxjs/toolkit'
+import firebase from '../../common/firebase/firebaseClient'
+
+interface DocumentInfo {
+  name: string
+  status: string
+  fileSize: number
+  modifiedAt: string
+  tags: string[] | undefined
+}
+
+type DocumentInfoState = {
+  isFetching: boolean
+  hasMoreItems: boolean
+  tableData: [] | DocumentInfo[]
+  snapshot:
+    | firebase.firestore.QuerySnapshot<firebase.firestore.DocumentData>
+    | undefined
+  rowsPerPage: number
+}
+
+const initialState: DocumentInfoState = {
+  isFetching: false,
+  hasMoreItems: true,
+  rowsPerPage: 10,
+  tableData: [],
+  snapshot: undefined
+}
+
+const documentInfoSlice = createSlice({
+  name: 'documentInfo',
+  initialState,
+  reducers: {},
+  extraReducers: {}
+})
+
+const { reducer, actions } = documentInfoSlice
+export { actions }
+export default reducer

--- a/src/redux/store.ts
+++ b/src/redux/store.ts
@@ -5,10 +5,12 @@ import {
   TypedUseSelectorHook
 } from 'react-redux'
 import authReducer from './auth/authSlice'
+import documentInfoReducer from './documentInfo/documentInfoSlice'
 
 const store = configureStore({
   reducer: {
-    auth: authReducer
+    auth: authReducer,
+    documentInfo: documentInfoReducer
   }
 })
 

--- a/src/schema/user.ts
+++ b/src/schema/user.ts
@@ -7,9 +7,23 @@ export type User = {
   affilication?: string | null
   photoURL?: string | null
   workspaces?: string[] | null // workspaceのID Referenceは一旦使わない
-  createdAt: firebase.firestore.FieldValue
-  updatedAt: firebase.firestore.FieldValue
-  lastLoginDate: firebase.firestore.FieldValue
+  createdAt: firebase.firestore.Timestamp
+  updatedAt: firebase.firestore.Timestamp
+  lastLoginDate: firebase.firestore.Timestamp
+  // lastLoginIP?: string
+  // changelog {} //更新ログを残す場合
+}
+
+export type UserData = {
+  name?: string
+  email?: string
+  role: string
+  affilication?: string | null
+  photoURL?: string | null
+  workspaces?: string[] | null // workspaceのID Referenceは一旦使わない
+  createdAt: string
+  updatedAt: string
+  lastLoginDate: string
   // lastLoginIP?: string
   // changelog {} //更新ログを残す場合
 }

--- a/src/tests/redux/authSlice.test.ts
+++ b/src/tests/redux/authSlice.test.ts
@@ -15,9 +15,9 @@ describe('Auth Reducer のテスト', () => {
     expect(store.getState().auth.uid).toBe('aiueo')
   })
 
-  test('logoutでstateがリセットされる', () => {
+  test('logoutでstateがリセットされる', async () => {
     store.dispatch(setUserId('aiueo'))
-    store.dispatch(logout())
+    await store.dispatch(logout())
     const { loading, uid, user, errors } = store.getState().auth
     expect(loading).toBe(false)
     expect(uid).toBe(undefined)

--- a/src/tests/redux/documentSlice.test.ts
+++ b/src/tests/redux/documentSlice.test.ts
@@ -1,0 +1,41 @@
+/* eslint-disable no-console */
+import store from './../../redux/store'
+/*
+import { fetchDocumentInfo } from '../../redux/documentInfo/documentInfoSlice'
+import { auth } from '../../common/firebase/firebaseClient'
+import { setUserId } from '../../redux/auth/authSlice'
+*/
+
+describe('Document Reducer のテスト', () => {
+  /*
+  beforeAll(async () => {
+    const email = process.env.REACT_APP_TEST_USER_EMAIL as string
+    const password = process.env.REACT_APP_TEST_USER_PASSWORD as string
+    const uid = process.env.REACT_APP_TEST_USER_UID as string
+
+    try {
+      await auth.signInWithEmailAndPassword(email, password)
+    } catch (error) {
+      console.log(error)
+    }
+    store.dispatch(setUserId(uid))
+  })
+  */
+
+  test('初期状態の確認', () => {
+    const {
+      isFetching,
+      hasMoreItems,
+      rowsPerPage,
+      tableData,
+      snapshot,
+      errors
+    } = store.getState().documentInfo
+    expect(isFetching).toBe(false)
+    expect(hasMoreItems).toBe(true)
+    expect(rowsPerPage).toEqual(10)
+    expect(tableData).toEqual([])
+    expect(snapshot).toBe(undefined)
+    expect(errors).toEqual({})
+  })
+})


### PR DESCRIPTION
#11 
Reduxにテーブル情報を保持し、ページ間移動でもロードなしにデータを表示できるようにする

- [ ] documentInfoSlice を作成する
- [ ] テーブルフェッチ処理をReduxに移植する
- [ ] テーブルの整形処理(normalize)をReduxに移植する
- [ ] documentInfoSlice内でauthSliceの情報を参照できるようにする